### PR TITLE
Syntax fix for verilator

### DIFF
--- a/axi_node_wrap.sv
+++ b/axi_node_wrap.sv
@@ -68,8 +68,8 @@ module axi_node_wrap
     input logic                                                          rst_n,
 
     //MASTER PORTS
-    AXI_BUS.Slave                                                        axi_port_slave  [N_SLAVE_PORT],
-    AXI_BUS.Master                                                       axi_port_master [N_MASTER_PORT],
+    AXI_BUS.Slave                                                        axi_port_slave  [N_SLAVE_PORT:N_SLAVE_PORT],
+    AXI_BUS.Master                                                       axi_port_master [N_MASTER_PORT:N_MASTER_PORT],
 
     `ifdef USE_CFG_BLOCK
         `ifdef USE_AXI_LITE

--- a/axi_node_wrap_with_slices.sv
+++ b/axi_node_wrap_with_slices.sv
@@ -72,8 +72,8 @@ module axi_node_wrap_with_slices
     input logic                                                          test_en_i,
 
     //MASTER PORTS
-    AXI_BUS.Slave                                                        axi_port_slave  [N_SLAVE_PORT],
-    AXI_BUS.Master                                                       axi_port_master [N_MASTER_PORT],
+    AXI_BUS.Slave                                                        axi_port_slave  [N_SLAVE_PORT:N_SLAVE_PORT],
+    AXI_BUS.Master                                                       axi_port_master [N_MASTER_PORT:N_MASTER_PORT],
 
 `ifdef USE_CFG_BLOCK
     `ifdef USE_AXI_LITE


### PR DESCRIPTION
Syntax fix to make verilator happy. Honestly, I'm not sure if this is the right thing to do, but I can still run the pulpino testbench in modelsim without any problems
