### PR TITLE
Potential forbidden axi write handshake dependency in debugging unit (#182)

### DIFF
--- a/axi_AW_allocator.sv
+++ b/axi_AW_allocator.sv
@@ -130,7 +130,7 @@ always @(posedge clk) begin
     if(rst_n == 1'b0)
         r_busy <= 0;
     else
-        r_busy <= awvalid_o & ~awready_o;
+        r_busy <= awvalid_o & ~|awready_o;
 end
 assign push_ID_o = (awvalid_o & (awvalid_o ^ r_busy)) & grant_FIFO_ID_i;
 

--- a/axi_AW_allocator.sv
+++ b/axi_AW_allocator.sv
@@ -115,21 +115,24 @@ assign        awid_o[AXI_ID_OUT-1:AXI_ID_IN] = ID_o[LOG_N_TARG+N_TARG_PORT-1:N_T
 assign        awready_o = {N_TARG_PORT{grant_FIFO_ID_i}} & awready_int;
 assign        awvalid_o = awvalid_int & grant_FIFO_ID_i;
 
-//assign        push_ID_o = awvalid_o & awready_i & grant_FIFO_ID_i;
-// we push the first cycle that awvalid is asserted
+
+// Original code contains false dependency
+//   - AXI4 standard: 'the master must not wait for the slave to assert AWREADY or WREADY before asserting AWVALID or WVALID'
+//   - original code: assign push_ID_o = awvalid_o & awready_i & grant_FIFO_ID_i;
+
+// Therefore, push awvalid the first cycle that awvalid is asserted
+//   case 1: awvalid is asserted before awready is asserted
+//     - awvalid is pushed once. If awready goes high, r_busy is cleared for the next cycle.
+//   case 2: awvalid is asserted while awready is asserted (e.g. default accept)
+//     - awvalid is pushed, and r_busy is cleared for the next cycle.
 logic r_busy; 
 always @(posedge clk) begin
     if(rst_n == 1'b0)
-        r_busy <= 0; //reset condition
-    else begin
-        if (awready_o == 1'b0)
-            r_busy <= awvalid_o; // acknowledge delayed; only issue push once
-        else
-            r_busy <= 0; // acknowledge issued; keep pushing until aw_ready_o goes low
-    end
+        r_busy <= 0;
+    else
+        r_busy <= awvalid_o & ~awready_o;
 end
 assign push_ID_o = (awvalid_o & (awvalid_o ^ r_busy)) & grant_FIFO_ID_i;
-// end (added)
 
 
 generate


### PR DESCRIPTION
Hi,

Since I've opened this issue on an axi handshaking issue in the interconnect, there has not been provided a fix yet, despite the issue being closed. The details of the problem can be found here: `https://github.com/pulp-platform/pulpino/issues/182`.

To summarize, the AXI interconnect contains a false dependency between AWVALID and WVALID. More specifically, it breaks the following condition (see AXI4 standard): 'the master must not wait for the slave to assert AWREADY or WREADY before asserting AWVALID or WVALID'

This pull request seems to fix this issue for me. Please do check the existing functionality for yourself as well, as I did not run this thing through a protocol checker yet.

Kind regards,

Barry