### PR TITLE
Add dependencies for IPApproX toolflow

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -3,8 +3,8 @@ package:
   description: "An efficient AXI4 interconnect"
 
 dependencies:
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.7.5 }
-  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.4.5 }
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.13.1 }
+  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.7.0 }
 
 sources:
   - src/apb_regs_top.sv

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -1,0 +1,24 @@
+#
+# List of IPs and relative branch/commit-hash/tag.
+# Uses the YAML syntax.
+#
+# Examples:
+#
+#   or10n:
+#     commit: tags/PULP3_final
+#     domain: [cluster]
+#   udma:
+#     commit: 62b10440
+#     domain: [soc]
+#   axi_slice:
+#     commit: master
+#     domain: [soc,cluster]
+# If a *tag* or *commit* is referenced, the IP will be in a
+#  state of DETACHED HEAD. Before committing any additional
+#  work, make sure to checkout a branch.
+#
+
+common_cells:
+  commit: v1.13.1
+axi:
+  commit: v0.7.0

--- a/src_files.yml
+++ b/src_files.yml
@@ -1,4 +1,8 @@
 axi_node:
+  vlog_opts: [
+    -L common_cells_lib,
+    -L axi_lib,
+  ]
   incdirs: [
     ./src/,
   ]


### PR DESCRIPTION
This adds missing dependencies to `axi_node` (which already noted in `bender.yml`). This is also likely to solve the workaround proposed in #11 .